### PR TITLE
Set up Terraform providers and backend configuration

### DIFF
--- a/envs/au-dev/c1-versions.tf
+++ b/envs/au-dev/c1-versions.tf
@@ -19,3 +19,7 @@ terraform {
     }
   }
 }
+
+provider "azurerm" {
+  features {}
+}


### PR DESCRIPTION
Terraform provider setup for au-dev. azurerm ~> 4.0, random ~> 3.0.
Backend points to the bootstrap storage account created in #3.
This is the starting point — terraform init works after this.

Closes #5
