### PR TITLE
AKS user node pool, IAM and wire into au-dev

### DIFF
--- a/envs/au-dev/c4-main.tf
+++ b/envs/au-dev/c4-main.tf
@@ -1,6 +1,10 @@
 # =============================================================================
 # Module Orchestration — au-dev
-# Modules are added here as they're built. VNet first, rest follows.
+#
+# DEPENDENCY ORDER:
+#   Resource Group (c3-locals.tf)
+#     ├── VNet, ACR, Monitoring (Tier 1 — independent, parallel)
+#     └── AKS Cluster (Tier 2 — needs VNet + ACR + Monitoring)
 # =============================================================================
 
 # --- VNet (everything needs this) ---
@@ -38,4 +42,31 @@ module "monitoring" {
   location            = var.location
   alert_email         = var.alert_email
   monthly_budget      = var.monthly_budget
+}
+
+# =============================================================================
+# TIER 2: Depends on VNet + ACR + Monitoring
+# =============================================================================
+
+# --- AKS Cluster (needs VNet subnets, ACR for pull, Log Analytics for monitoring) ---
+
+module "aks_cluster" {
+  source = "../../modules/aks-cluster"
+
+  name_prefix                = local.name_prefix
+  common_tags                = local.common_tags
+  resource_group_name        = azurerm_resource_group.main.name
+  location                   = var.location
+  cluster_name               = var.cluster_name
+  kubernetes_version         = var.kubernetes_version
+  private_app_subnet_ids     = module.vnet.private_app_subnet_ids
+  node_vm_size               = var.node_vm_size
+  node_min_count             = var.node_min_count
+  node_max_count             = var.node_max_count
+  node_count                 = var.node_count
+  acr_id                     = module.acr.acr_id
+  log_analytics_workspace_id = module.monitoring.log_analytics_workspace_id
+  enable_monitoring          = true
+
+  depends_on = [module.vnet, module.acr, module.monitoring]
 }

--- a/envs/au-dev/c5-outputs.tf
+++ b/envs/au-dev/c5-outputs.tf
@@ -12,3 +12,13 @@ output "acr_login_server" {
   description = "Login server URL for the ACR"
   value       = module.acr.acr_login_server
 }
+
+output "cluster_name" {
+  description = "Name of the AKS cluster"
+  value       = module.aks_cluster.cluster_name
+}
+
+output "configure_kubectl" {
+  description = "Command to configure kubectl"
+  value       = "az aks get-credentials --resource-group ${azurerm_resource_group.main.name} --name ${module.aks_cluster.cluster_name}"
+}

--- a/modules/aks-cluster/c4-node-pool.tf
+++ b/modules/aks-cluster/c4-node-pool.tf
@@ -1,0 +1,20 @@
+# User Node Pool for Application Workloads
+resource "azurerm_kubernetes_cluster_node_pool" "user" {
+  name                  = "user"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.main.id
+  vm_size               = var.node_vm_size
+  node_count            = var.node_count
+  min_count             = var.node_min_count
+  max_count             = var.node_max_count
+  auto_scaling_enabled  = true
+  vnet_subnet_id        = var.private_app_subnet_ids[0]
+  os_disk_size_gb       = 30
+
+  node_labels = {
+    "workload" = "app"
+  }
+
+  tags = merge(var.common_tags, {
+    Name = "${var.cluster_name}-user-nodepool"
+  })
+}

--- a/modules/aks-cluster/c5-iam.tf
+++ b/modules/aks-cluster/c5-iam.tf
@@ -1,0 +1,7 @@
+# ACR Pull Role Assignment for AKS Kubelet Identity
+resource "azurerm_role_assignment" "acr_pull" {
+  principal_id                     = azurerm_kubernetes_cluster.main.kubelet_identity[0].object_id
+  role_definition_name             = "AcrPull"
+  scope                            = var.acr_id
+  skip_service_principal_aad_check = true
+}

--- a/modules/aks-cluster/c6-outputs.tf
+++ b/modules/aks-cluster/c6-outputs.tf
@@ -1,0 +1,54 @@
+output "cluster_name" {
+  description = "Name of the AKS cluster"
+  value       = azurerm_kubernetes_cluster.main.name
+}
+
+output "cluster_id" {
+  description = "ID of the AKS cluster"
+  value       = azurerm_kubernetes_cluster.main.id
+}
+
+output "kube_config_raw" {
+  description = "Raw kubeconfig for the AKS cluster"
+  value       = azurerm_kubernetes_cluster.main.kube_config_raw
+  sensitive   = true
+}
+
+output "host" {
+  description = "Kubernetes API server host"
+  value       = azurerm_kubernetes_cluster.main.kube_config[0].host
+  sensitive   = true
+}
+
+output "client_certificate" {
+  description = "Client certificate for authentication"
+  value       = azurerm_kubernetes_cluster.main.kube_config[0].client_certificate
+  sensitive   = true
+}
+
+output "client_key" {
+  description = "Client key for authentication"
+  value       = azurerm_kubernetes_cluster.main.kube_config[0].client_key
+  sensitive   = true
+}
+
+output "cluster_ca_certificate" {
+  description = "Cluster CA certificate"
+  value       = azurerm_kubernetes_cluster.main.kube_config[0].cluster_ca_certificate
+  sensitive   = true
+}
+
+output "oidc_issuer_url" {
+  description = "OIDC issuer URL for workload identity"
+  value       = azurerm_kubernetes_cluster.main.oidc_issuer_url
+}
+
+output "kubelet_identity_object_id" {
+  description = "Object ID of the kubelet managed identity"
+  value       = azurerm_kubernetes_cluster.main.kubelet_identity[0].object_id
+}
+
+output "key_vault_secrets_provider_identity" {
+  description = "Identity of the Key Vault secrets provider"
+  value       = azurerm_kubernetes_cluster.main.key_vault_secrets_provider[0].secret_identity[0].object_id
+}


### PR DESCRIPTION
User node pool for app workloads (label: workload=app) plus AcrPull role so AKS can pull images from our registry. Outputs expose cluster name, kubeconfig, and OIDC issuer URL for workload identity setup.

Closes #14
